### PR TITLE
Configure Neon database connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # TchatRecoSong
-listing  of recommended songs by twitch tchat
+
+Listing of recommended songs by Twitch tchat.
+
+## Base de données Neon
+
+Le backend FastAPI est désormais prêt à se connecter à l'instance Neon fournie par défaut. Si aucune variable d'environnement `DATABASE_URL` n'est définie, la connexion utilisera automatiquement l'URL suivante :
+
+```
+postgresql://neondb_owner:npg_ljrtUWJ9o7Cs@ep-plain-leaf-ag9ynkn2-pooler.c-2.eu-central-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require
+```
+
+Pour initialiser les tables (`songs` et `ban_rules`) directement dans Neon, importez le fichier SQL `backend/app/database/neon_schema.sql` via l'outil SQL du tableau de bord Neon ou avec `psql`.

--- a/backend/app/database/connection.py
+++ b/backend/app/database/connection.py
@@ -6,7 +6,13 @@ from dotenv import load_dotenv
 # Charger .env en local
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+DEFAULT_NEON_URL = (
+    "postgresql://neondb_owner:npg_ljrtUWJ9o7Cs@"
+    "ep-plain-leaf-ag9ynkn2-pooler.c-2.eu-central-1.aws.neon.tech/"
+    "neondb?sslmode=require&channel_binding=require"
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", DEFAULT_NEON_URL)
 if not DATABASE_URL:
     raise ValueError("❌ DATABASE_URL non défini.")
 

--- a/backend/app/database/neon_schema.sql
+++ b/backend/app/database/neon_schema.sql
@@ -1,0 +1,26 @@
+-- Schema initial pour l'instance Neon
+-- Cette requête peut être exécutée via le tableau de bord SQL ou psql.
+
+CREATE TABLE IF NOT EXISTS songs (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    artist TEXT,
+    link TEXT UNIQUE,
+    thumbnail TEXT,
+    votes INTEGER DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_songs_title ON songs (title);
+CREATE INDEX IF NOT EXISTS idx_songs_artist ON songs (artist);
+CREATE INDEX IF NOT EXISTS idx_songs_link ON songs (link);
+
+CREATE TABLE IF NOT EXISTS ban_rules (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    artist TEXT,
+    link TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ban_rules_title ON ban_rules (title);
+CREATE INDEX IF NOT EXISTS idx_ban_rules_artist ON ban_rules (artist);
+CREATE INDEX IF NOT EXISTS idx_ban_rules_link ON ban_rules (link);


### PR DESCRIPTION
## Summary
- default the backend database URL to the provided Neon PostgreSQL instance
- add a reusable SQL schema file to create the songs and ban rules tables on Neon
- document the Neon setup and schema import in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4028be87083228bd93fcbedb1a046