### PR TITLE
Resolve merge conflict markers in backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ soumission, portail `/submit`, redirection du routeur Vue, etc.). Si tu
 viens de fusionner ou de déployer, assure-toi que le service Render
 utilise bien cette révision.
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 Twitch interdit d'envoyer des liens cliquables directement dans le tchat. Le bot
 `!reco` doit donc se contenter d'afficher l'URL publique de la page "utilisateur"
 hébergée par ce dépôt (ex. `https://tchatrecosong-front.onrender.com/submit`). Les viewers y collent
@@ -36,23 +32,13 @@ Ton projet est déjà relié à une base Neon. Quand tu actives l'intégration G
 3. Renseigne `DATABASE_URL` comme nom, et colle l'URL Neon nettoyée (voir remarques ci-dessous) comme valeur.
 4. Clique sur **Save Changes**, puis déclenche un redéploiement via **Manual Deploy > Deploy latest commit** pour que la nouvelle URL soit prise en compte.
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 > ❌ Neon affiche parfois un suffixe `&channel_binding=require`. Supprime-le : libpq/psycopg2 utilisé sur Render ne gère pas cette option et échouera avec une erreur d'authentification. Garde simplement `?sslmode=require` dans l'URL finale.
 
 > ⚠️ Neon affiche souvent un exemple sous la forme `psql 'postgresql://...'`. Ne recopie que la partie `postgresql://…` (sans le préfixe `psql` ni les quotes), sinon la connexion échouera.
 
-<<<<<<< HEAD
 
 > 💡  Si tu préfères utiliser les champs détaillés (hôte, port, utilisateur…), Neon les expose aussi depuis l'onglet **Connection Details**. Tu peux alors définir `DATABASE_USER`, `DATABASE_PASSWORD`, etc. en local : le backend reconstruira automatiquement `DATABASE_URL` à partir de ces valeurs.
 
-
-=======
-> 💡  Si tu préfères utiliser les champs détaillés (hôte, port, utilisateur…), Neon les expose aussi depuis l'onglet **Connection Details**. Tu peux alors définir `DATABASE_USER`, `DATABASE_PASSWORD`, etc. en local : le backend reconstruira automatiquement `DATABASE_URL` à partir de ces valeurs.
-
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 Pour initialiser les tables (`songs`, `ban_rules`) dans Neon, exécute le script SQL `backend/app/database/neon_schema.sql` via l'interface SQL Neon ou avec `psql`.
 
 ### Vérifier ta configuration localement
@@ -69,10 +55,6 @@ La commande exécute un `SELECT 1` sur la base ciblée et affiche les paramètre
 ### Utilisation avec Render PostgreSQL
 
 - Render fournit plusieurs variables système, mais **seule** `DATABASE_URL` est lue par le backend. Assure-toi de mettre cette clé à jour dans l'onglet **Environment** après chaque rotation de mot de passe.
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 - Si tu renseignes manuellement les champs (`DATABASE_HOST`, `DATABASE_PORT`, ...), assure-toi que le nom d'hôte contient bien le domaine complet (ex. `dpg-...frankfurt-postgres.render.com`). L'erreur `could not translate host name` indiquée par SQLAlchemy signifie que l'hôte est tronqué.
 - Un champ `sslmode` sera ajouté automatiquement (valeur `require` par défaut) si aucun paramètre n'est précisé. Tu peux le forcer via `DATABASE_SSLMODE=require` si ton hébergeur n'ajoute pas ce paramètre à l'URL.
 
@@ -80,16 +62,6 @@ La commande exécute un `SELECT 1` sur la base ciblée et affiche les paramètre
 
 Chaque dossier (`backend/`, `frontend/`) contient un fichier `.env.example` à
 copier en `.env` puis à personnaliser avant de lancer l'application ou de créer
-<<<<<<< HEAD
-les variables d'environnement sur Render. Chaque clé est commentée directement
-dans ces fichiers, mais voici un rappel synthétique :
-
-| Variable | À renseigner avec... |
-| --- | --- |
-
-| `DATABASE_URL` | L'URL PostgreSQL fournie par Render (ou Neon) pour la base de données. C'est la seule clé lue par le backend en production. |
-
-=======
 les variables d'environnement sur Render. Les fichiers `.env` réels ne sont pas
 versionnés : garde-les en local (ou sur Render) et ne les commits pas. Chaque clé
 est commentée directement dans ces fichiers, mais voici un rappel synthétique :
@@ -97,7 +69,6 @@ est commentée directement dans ces fichiers, mais voici un rappel synthétique�
 | Variable | À renseigner avec... |
 | --- | --- |
 | `DATABASE_URL` | L'URL PostgreSQL fournie par Render (ou Neon) pour la base de données. C'est la seule clé lue par le backend en production. |
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 | `CORS_ORIGINS` | Les domaines autorisés à appeler l'API, séparés par des virgules. |
 | `ADMIN_JWT_SECRET` | Une chaîne secrète longue et aléatoire pour signer les JWT admin. |
 | `ADMIN_TOKEN_TTL_MINUTES` | Durée de validité des tokens admin (720 = 12 h). |
@@ -115,10 +86,6 @@ est commentée directement dans ces fichiers, mais voici un rappel synthétique�
 > les clients OAuth et les listes d'administrateurs). Un mot de passe erroné côté Neon ou Render
 > provoquera un arrêt immédiat du backend.
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 ### URLs frontend prêtes à l'emploi
 
 - Portail public (viewers) : `https://tchatrecosong-front.onrender.com/submit`

--- a/backend/app/database/connection.py
+++ b/backend/app/database/connection.py
@@ -1,31 +1,15 @@
 import logging
 import os
-<<<<<<< HEAD
-
 from typing import Dict, Optional
-
-
-=======
-from typing import Dict, Optional
-
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 from dotenv import load_dotenv
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import URL, make_url
 from sqlalchemy.exc import ArgumentError, OperationalError
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 # Charger .env en local
 load_dotenv()
 
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 logger = logging.getLogger(__name__)
 
 
@@ -55,10 +39,6 @@ def _connection_snapshot(url_str: str) -> Dict[str, Optional[str]]:
         "query": "&".join(f"{k}={v}" for k, v in url_obj.query.items()) or None,
     }
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 def _normalize_host(host: Optional[str]) -> Optional[str]:
     if not host:
         return host
@@ -148,10 +128,6 @@ def _normalize_url(raw_url: str) -> Optional[str]:
         query.pop("channel_binding", None)
         url_obj = url_obj.set(query=query)
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     normalized_host = _normalize_host(url_obj.host)
     if normalized_host != url_obj.host:
         url_obj = url_obj.set(host=normalized_host)
@@ -167,10 +143,6 @@ def _normalize_url(raw_url: str) -> Optional[str]:
     return str(url_obj)
 
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 PLACEHOLDER_SETS = {
     "user": {"USER", "USERNAME"},
     "password": {"PASSWORD"},
@@ -253,10 +225,6 @@ def _build_url_from_parts() -> Optional[str]:
 
 
 def _determine_database_url() -> str:
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     raw_database_url = os.getenv("DATABASE_URL")
     if raw_database_url:
         normalized = _normalize_url(raw_database_url)
@@ -267,25 +235,14 @@ def _determine_database_url() -> str:
             "depuis Neon/Render (sans le préfixe `psql` ni les quotes)."
         )
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     assembled = _build_url_from_parts()
     if assembled:
         logger.info("DATABASE_URL assemblée à partir des variables individuelles.")
         return assembled
 
     raise RuntimeError(
-<<<<<<< HEAD
-
         "La variable `DATABASE_URL` n'est pas définie. Renseigne-la avec l'URL fournie "
         "par Neon ou Render dans les variables d'environnement du service."
-
-=======
-        "La variable `DATABASE_URL` n'est pas définie. Renseigne-la avec l'URL fournie "
-        "par Neon ou Render dans les variables d'environnement du service."
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,10 +7,6 @@ from sqlalchemy.exc import OperationalError
 from app.config import CORS_ORIGINS
 from app.api.routes import songs, ban_rules, public_submissions, auth
 from app import models  # noqa: F401 - ensure models are imported before create_all
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 from app.database.connection import Base, check_connection, describe_active_database, engine
 
 logger = logging.getLogger(__name__)
@@ -24,15 +20,8 @@ except OperationalError as exc:  # pragma: no cover - dépend de l'env d'exécut
     logger.error(
         "Échec de connexion PostgreSQL avec les paramètres %s", snapshot, exc_info=exc
     )
-<<<<<<< HEAD
-
     raise RuntimeError(
         "Connexion à la base de données impossible. Vérifie la variable `DATABASE_URL` "
-
-=======
-    raise RuntimeError(
-        "Connexion à la base de données impossible. Vérifie la variable `DATABASE_URL` "
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
         "et les identifiants configurés sur Render ou Neon."
     ) from exc
 

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -57,10 +57,6 @@ def authenticate_google(credential: str) -> tuple[str, str]:
     if not GOOGLE_CLIENT_ID:
         raise AdminAuthError("GOOGLE_CLIENT_ID non configuré")
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     token_info_url = "https://oauth2.googleapis.com/tokeninfo"
     params = {"id_token": credential}
     with httpx.Client(timeout=5.0) as client:
@@ -80,10 +76,6 @@ def authenticate_google(credential: str) -> tuple[str, str]:
         raise AdminAuthError("Adresse non autorisée", status.HTTP_403_FORBIDDEN)
 
     name = idinfo.get("name") or email or "Google Admin"
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     subject = f"google:{idinfo.get('sub')}"
     token = issue_admin_token(subject=subject, name=name, provider="google")
     return token, name

--- a/frontend/src/assets/styles/_variables.scss
+++ b/frontend/src/assets/styles/_variables.scss
@@ -7,13 +7,8 @@ $accent-color: #e67e22;
 $background-color: #0f172a;
 $text-color: #f8fafc;
 $muted-color: #94a3b8;
-<<<<<<< HEAD
-
 $twitch-color: #9146ff;
 
-=======
-$twitch-color: #9146ff;
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
 
 $spacing: 10px;
 $spacing-small: 12px;

--- a/frontend/src/assets/styles/app.scss
+++ b/frontend/src/assets/styles/app.scss
@@ -118,10 +118,6 @@ body {
     @include card-style;
     display: grid;
     gap: $spacing-medium;
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     justify-items: center;
 
     button {
@@ -142,21 +138,11 @@ body {
       > div {
         width: 100% !important;
       }
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
     }
 
     .twitch-login {
       display: inline-flex;
-<<<<<<< HEAD
-
       justify-content: center;
-
-=======
-      justify-content: center;
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
       align-items: center;
       gap: $spacing-small;
       padding: $spacing-small $spacing-large;

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -10,10 +10,6 @@
     <div v-if="!token" class="login-options">
       <p>Connectez-vous avec un compte autorisé pour gérer les recommandations.</p>
       <div id="google-login" class="login-button" v-if="googleClientId"></div>
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
       <button
         v-if="twitchClientId"
         type="button"
@@ -30,10 +26,6 @@
         </span>
         <span class="label">Login with Twitch</span>
       </button>
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/codex/find-the-best-solution-to-retrieve-chat-command-wlivcu
       <p class="login-hint">
         Configurez les variables <code>VITE_GOOGLE_CLIENT_ID</code> et <code>VITE_TWITCH_CLIENT_ID</code> si nécessaire.
       </p>


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers across backend, documentation, and frontend sources
- restore backend startup imports and error handling after resolving the conflicts
- clean up admin styles and README guidance so the UI and docs read correctly again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88dd655748322b6a05f666d7ea4e3