### PR TITLE
Handle Google issuer validation manually

### DIFF
--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -128,16 +128,17 @@ def authenticate_google(credential: str) -> tuple[str, str]:
             public_key,
             algorithms=["RS256"],
             audience=GOOGLE_CLIENT_ID,
-            issuer=list(GOOGLE_ISSUERS),
+            options={"verify_iss": False},
         )
     except jwt.ExpiredSignatureError:
         raise AdminAuthError("Token Google expiré")
     except jwt.InvalidAudienceError:
         raise AdminAuthError("Client Google non autorisé")
-    except jwt.InvalidIssuerError:
-        raise AdminAuthError("Émetteur Google invalide")
     except PyJWTError as exc:  # pragma: no cover - dépend du token reçu
         raise AdminAuthError("Token Google invalide") from exc
+
+    if idinfo.get("iss") not in GOOGLE_ISSUERS:
+        raise AdminAuthError("Émetteur Google invalide")
 
     email = idinfo.get("email")
     if ALLOWED_GOOGLE_EMAILS and email not in ALLOWED_GOOGLE_EMAILS:


### PR DESCRIPTION
## Summary
- disable automatic issuer verification when decoding Google credentials
- perform a manual whitelist check of the Google token issuer before issuing an admin token

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da9e7ae31c83229d009a50c693260f