### PR TITLE
Refactor environment configuration logging initialization

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,71 +29,127 @@ def _format_env_value(value: str | None, mask: bool = False) -> str:
     return value
 
 
-def _log_env_value(name: str, value: str | None, mask: bool = False) -> None:
-    logger.info("%s (env): %s", name, _format_env_value(value, mask=mask))
+def _log_env_value(
+    name: str,
+    value: str | None,
+    mask: bool = False,
+    *,
+    target_logger: logging.Logger | None = None,
+) -> None:
+    active_logger = target_logger or logger
+    active_logger.info("%s (env): %s", name, _format_env_value(value, mask=mask))
 
 
 
-def _log_collection(name: str, values: Iterable[str]) -> None:
+def _log_collection(
+    name: str,
+    values: Iterable[str],
+    *,
+    target_logger: logging.Logger | None = None,
+) -> None:
     values_list = list(values)
+    active_logger = target_logger or logger
     if values_list:
-        logger.info("%s interprétée: %s", name, values_list)
+        active_logger.info("%s interprétée: %s", name, values_list)
     else:
-        logger.info("%s interprétée: <vide>", name)
+        active_logger.info("%s interprétée: <vide>", name)
 
 
 # Liste des origines autorisées pour CORS
 _default_cors = "https://tchatrecosong-front.onrender.com,http://localhost:5173"
-_raw_cors = os.getenv("CORS_ORIGINS")
-_log_env_value("CORS_ORIGINS", _raw_cors)
-
-if _raw_cors is None:
-    logger.info(
-        "CORS_ORIGINS non définie, utilisation de la valeur par défaut: %s",
-        _default_cors,
-    )
-    _raw_cors = _default_cors
+_raw_cors_env = os.getenv("CORS_ORIGINS")
+_cors_used_default = _raw_cors_env is None
+_raw_cors = _raw_cors_env or _default_cors
 
 CORS_ORIGINS = _split_env(_raw_cors)
-_log_collection("CORS_ORIGINS", CORS_ORIGINS)
 
 # Authentification administrateur
-_raw_admin_secret = os.getenv("ADMIN_JWT_SECRET")
+_default_admin_secret = "super-secret-change-me"
+_raw_admin_secret_env = os.getenv("ADMIN_JWT_SECRET")
+_admin_secret_used_default = _raw_admin_secret_env is None
+ADMIN_JWT_SECRET = _raw_admin_secret_env or _default_admin_secret
 
-_log_env_value("ADMIN_JWT_SECRET", _raw_admin_secret, mask=True)
-
-if _raw_admin_secret is None:
-    logger.info(
-        "ADMIN_JWT_SECRET non définie, utilisation de la valeur par défaut: %s",
-        _mask_secret("super-secret-change-me"),
-    )
-    _raw_admin_secret = "super-secret-change-me"
-
-ADMIN_JWT_SECRET = _raw_admin_secret
-
-_raw_admin_ttl = os.getenv("ADMIN_TOKEN_TTL_MINUTES")
-_log_env_value("ADMIN_TOKEN_TTL_MINUTES", _raw_admin_ttl)
-if _raw_admin_ttl is None:
-    logger.info("ADMIN_TOKEN_TTL_MINUTES non définie, valeur par défaut: 720")
-    _raw_admin_ttl = "720"
+_raw_admin_ttl_env = os.getenv("ADMIN_TOKEN_TTL_MINUTES")
+_admin_ttl_used_default = _raw_admin_ttl_env is None
+_raw_admin_ttl = _raw_admin_ttl_env or "720"
 ADMIN_TOKEN_TTL_MINUTES = int(_raw_admin_ttl)
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
-_log_env_value("GOOGLE_CLIENT_ID", GOOGLE_CLIENT_ID)
 
 TWITCH_CLIENT_ID = os.getenv("TWITCH_CLIENT_ID")
-_log_env_value("TWITCH_CLIENT_ID", TWITCH_CLIENT_ID)
 
 _raw_allowed_google = os.getenv("ALLOWED_GOOGLE_EMAILS", "")
-_log_env_value("ALLOWED_GOOGLE_EMAILS", _raw_allowed_google)
-
 ALLOWED_GOOGLE_EMAILS = set(_split_env(_raw_allowed_google))
-_log_collection("ALLOWED_GOOGLE_EMAILS", sorted(ALLOWED_GOOGLE_EMAILS))
 
 _raw_allowed_twitch = os.getenv("ALLOWED_TWITCH_LOGINS", "")
-
-_log_env_value("ALLOWED_TWITCH_LOGINS", _raw_allowed_twitch)
-
 ALLOWED_TWITCH_LOGINS = set(_split_env(_raw_allowed_twitch))
-_log_collection("ALLOWED_TWITCH_LOGINS", sorted(ALLOWED_TWITCH_LOGINS))
+
+
+def log_environment_configuration() -> None:
+    """Journalise la configuration issue des variables d'environnement."""
+
+    uvicorn_logger = logging.getLogger("uvicorn.error")
+    root_logger = logging.getLogger()
+    if uvicorn_logger.handlers or uvicorn_logger.hasHandlers():
+        active_logger = uvicorn_logger
+    elif root_logger.handlers:
+        active_logger = root_logger
+    else:
+        active_logger = logger
+
+    _log_env_value("CORS_ORIGINS", _raw_cors_env, target_logger=active_logger)
+    if _cors_used_default:
+        active_logger.info(
+            "CORS_ORIGINS non définie, utilisation de la valeur par défaut: %s",
+            _default_cors,
+        )
+    _log_collection("CORS_ORIGINS", CORS_ORIGINS, target_logger=active_logger)
+
+    _log_env_value(
+        "ADMIN_JWT_SECRET",
+        _raw_admin_secret_env,
+        mask=True,
+        target_logger=active_logger,
+    )
+    if _admin_secret_used_default:
+        active_logger.info(
+            "ADMIN_JWT_SECRET non définie, utilisation de la valeur par défaut: %s",
+            _mask_secret(_default_admin_secret),
+        )
+
+    _log_env_value(
+        "ADMIN_TOKEN_TTL_MINUTES",
+        _raw_admin_ttl_env,
+        target_logger=active_logger,
+    )
+    if _admin_ttl_used_default:
+        active_logger.info(
+            "ADMIN_TOKEN_TTL_MINUTES non définie, valeur par défaut: 720"
+        )
+
+    _log_env_value("GOOGLE_CLIENT_ID", GOOGLE_CLIENT_ID, target_logger=active_logger)
+
+    _log_env_value("TWITCH_CLIENT_ID", TWITCH_CLIENT_ID, target_logger=active_logger)
+
+    _log_env_value(
+        "ALLOWED_GOOGLE_EMAILS",
+        _raw_allowed_google,
+        target_logger=active_logger,
+    )
+    _log_collection(
+        "ALLOWED_GOOGLE_EMAILS",
+        sorted(ALLOWED_GOOGLE_EMAILS),
+        target_logger=active_logger,
+    )
+
+    _log_env_value(
+        "ALLOWED_TWITCH_LOGINS",
+        _raw_allowed_twitch,
+        target_logger=active_logger,
+    )
+    _log_collection(
+        "ALLOWED_TWITCH_LOGINS",
+        sorted(ALLOWED_TWITCH_LOGINS),
+        target_logger=active_logger,
+    )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.exc import OperationalError
 
-from app.config import CORS_ORIGINS
+from app.config import CORS_ORIGINS, log_environment_configuration
 from app.api.routes import songs, ban_rules, public_submissions, auth
 from app import models  # noqa: F401 - ensure models are imported before create_all
 from app.database.connection import Base, check_connection, describe_active_database, engine
@@ -31,6 +31,8 @@ async def startup_checks() -> None:
         )
     else:
         Base.metadata.create_all(bind=engine)
+
+    log_environment_configuration()
 
 # Middleware CORS
 app.add_middleware(


### PR DESCRIPTION
## Summary
- extract environment configuration logging into `log_environment_configuration()` so that constants stay initialized at import time while log emission is delayed
- select an appropriate active logger (Uvicorn error logger, root logger, or module logger) before writing configuration details to the logs
- invoke `log_environment_configuration()` from the FastAPI startup event to emit configuration details after Uvicorn logging is configured

## Testing
- uvicorn app.main:app --port 8000


------
https://chatgpt.com/codex/tasks/task_e_68daeb77abf88322b135c1b8262886cf