### PR TITLE
Adjust COOP headers for Google auth

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <title>TchatRecoSong</title>
     <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -31,7 +31,6 @@ function getContentType(filePath) {
 }
 
 function setCommonHeaders(res) {
-  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
   res.setHeader('Cross-Origin-Embedder-Policy', 'unsafe-none');
 }
 


### PR DESCRIPTION
## Summary
- stop emitting the Cross-Origin-Opener-Policy header from the frontend server
- remove the matching COOP meta tag from the HTML shell so it aligns with the server headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dce1839ed48322a7b41eac4b3a8f30