### PR TITLE
Relance le bouton Google après déconnexion

### DIFF
--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -211,6 +211,14 @@ watch(googleClientId, () => {
   scheduleGoogleInitRetry();
 });
 
+watch(token, async (newToken) => {
+  if (newToken === null) {
+    await nextTick();
+    ensureGoogleButton();
+    scheduleGoogleInitRetry();
+  }
+});
+
 onMounted(async () => {
   scheduleGoogleInitRetry();
   await fetchAuthConfig();


### PR DESCRIPTION
## Summary
- relancer l'initialisation du bouton Google quand le token d'admin devient nul
- garantir le ré-affichage du bouton après la déconnexion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf137698c83228c4a8d0c60d4a1af