### PR TITLE
Add COOP headers to production and dev servers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups">
     <title>TchatRecoSong</title>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -32,6 +32,7 @@ function getContentType(filePath) {
 
 function setCommonHeaders(res) {
   res.setHeader('Cross-Origin-Embedder-Policy', 'unsafe-none');
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
 }
 
 function sendFile(req, res, filePath, status = 200) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,10 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   server: {
-    port: 5173
+    port: 5173,
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+      'Cross-Origin-Embedder-Policy': 'unsafe-none'
+    }
   }
 })


### PR DESCRIPTION
## Summary
- ensure the static server sends both COOP and COEP headers
- add the COOP meta tag alongside the existing COEP meta tag in the HTML entry point
- configure the Vite dev server to mirror the COOP/COEP headers during development

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcfaae09a48322a460e93090a15116