### PR TITLE
Adjust COOP headers to allow Google auth messaging

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
-    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups">
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <title>TchatRecoSong</title>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -32,7 +32,7 @@ function getContentType(filePath) {
 
 function setCommonHeaders(res) {
   res.setHeader('Cross-Origin-Embedder-Policy', 'unsafe-none');
-  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
+  res.setHeader('Cross-Origin-Opener-Policy', 'unsafe-none');
 }
 
 function sendFile(req, res, filePath, status = 200) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     port: 5173,
     headers: {
-      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+      'Cross-Origin-Opener-Policy': 'unsafe-none',
       'Cross-Origin-Embedder-Policy': 'unsafe-none'
     }
   }


### PR DESCRIPTION
## Summary
- set the Cross-Origin-Opener-Policy header to `unsafe-none` across the HTML entrypoint, static server, and Vite dev server so Google auth messaging is permitted

## Testing
- npm install *(fails: registry returns 403 in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0318fa888322a6f4a5afeb7a53f1