### PR TITLE
Handle local API URL fallback

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,11 +1,18 @@
-export function getApiUrl(): string | null {
+const LOCAL_BACKEND_URL = 'http://localhost:8000';
+
+export function getApiUrl(): string {
   const configured = import.meta.env.VITE_API_URL;
   if (configured) {
     return configured.replace(/\/$/, '');
   }
 
   if (typeof window === 'undefined') {
-    return null;
+    throw new Error('VITE_API_URL doit être défini lorsque window est indisponible.');
+  }
+
+  const { hostname } = window.location;
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]') {
+    return LOCAL_BACKEND_URL;
   }
 
   try {
@@ -15,7 +22,6 @@ export function getApiUrl(): string | null {
     }
     return `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`.replace(/\/$/, '');
   } catch (error) {
-    console.warn('Impossible de déduire automatiquement VITE_API_URL', error);
-    return null;
+    throw new Error('Impossible de déduire automatiquement VITE_API_URL. Définissez VITE_API_URL pour votre déploiement.');
   }
 }


### PR DESCRIPTION
## Summary
- add a local backend fallback when running the frontend on localhost
- keep the Render hostname replacement while throwing clearer configuration errors

## Testing
- ⚠️ `npm --prefix frontend install` *(fails with 403 Forbidden when downloading dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dffd29c9cc8322ac5ea985c8828847