### PR TITLE
Relax COOP to allow Google auth popups

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
-    <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups">
     <title>TchatRecoSong</title>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -32,7 +32,7 @@ function getContentType(filePath) {
 
 function setCommonHeaders(res) {
   res.setHeader('Cross-Origin-Embedder-Policy', 'unsafe-none');
-  res.setHeader('Cross-Origin-Opener-Policy', 'unsafe-none');
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
 }
 
 function sendFile(req, res, filePath, status = 200) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     port: 5173,
     headers: {
-      'Cross-Origin-Opener-Policy': 'unsafe-none',
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
       'Cross-Origin-Embedder-Policy': 'unsafe-none'
     }
   }


### PR DESCRIPTION
## Summary
- relax the Cross-Origin-Opener-Policy header to same-origin-allow-popups in the Vite dev server, production server, and HTML template to unblock Google login communication

## Testing
- npm run build *(fails: vite executable missing because dependencies could not be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68dffbc28f3883229e4bc87e79cf9486