### PR TITLE
Remove COOP header to stop Google popup warnings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
-    <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <title>TchatRecoSong</title>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -32,7 +32,6 @@ function getContentType(filePath) {
 
 function setCommonHeaders(res) {
   res.setHeader('Cross-Origin-Embedder-Policy', 'unsafe-none');
-  res.setHeader('Cross-Origin-Opener-Policy', 'unsafe-none');
 }
 
 function sendFile(req, res, filePath, status = 200) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,6 @@ export default defineConfig({
   server: {
     port: 5173,
     headers: {
-      'Cross-Origin-Opener-Policy': 'unsafe-none',
       'Cross-Origin-Embedder-Policy': 'unsafe-none'
     }
   }


### PR DESCRIPTION
## Summary
- remove the Cross-Origin-Opener-Policy meta tag from the HTML entrypoint so Google login iframes can post messages without console errors
- stop sending the Cross-Origin-Opener-Policy header from both the dev server and the production Node static server

## Testing
- not run (environment only)


------
https://chatgpt.com/codex/tasks/task_e_68dffbc28f3883229e4bc87e79cf9486