### PR TITLE
Handle Twitch redirect configuration in admin view

### DIFF
--- a/frontend/src/services/adminAuth.ts
+++ b/frontend/src/services/adminAuth.ts
@@ -11,6 +11,7 @@ export interface AuthResponse {
 export interface AuthConfig {
   google_client_id?: string;
   twitch_client_id?: string;
+  twitch_redirect_uri?: string;
 }
 
 export async function exchangeAdminAuth(endpoint: AuthEndpoint, payload: Record<string, string>): Promise<AuthResponse> {


### PR DESCRIPTION
## Summary
- allow AdminView to derive a configurable Twitch redirect URI from env or API config
- redirect legacy hash-based Twitch callbacks to the dedicated callback route
- extend auth config typings to include optional Twitch redirect URI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0056d8d788322b1909a652dbfef24