### PR TITLE
Fix front-end router merge conflict and restore Twitch callback route

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import HomeView from './views/HomeView.vue';
 import AdminView from './views/AdminView.vue';
+import TwitchCallbackView from './views/TwitchCallbackView.vue';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -8,10 +9,7 @@ const router = createRouter({
     { path: '/', redirect: '/submit' },
     { path: '/submit', name: 'submit', component: HomeView },
     { path: '/admin', name: 'admin', component: AdminView },
-<<<<<<< HEAD
-=======
     { path: '/twitch-callback', name: 'twitch-callback', component: TwitchCallbackView },
->>>>>>> origin/codex/restore-code-from-merge-pr-#42-2x13fr
   ],
 });
 


### PR DESCRIPTION
## Summary
- resolve leftover merge conflict markers in the Vue router definition
- restore the Twitch callback route and import the corresponding view

## Testing
- npm run build *(fails: vite not found because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e18813e57c8322ad4b718d78bdac8f