### PR TITLE
Add Twitch admin hash fallback and regression test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "vue": "^3.5.18",
@@ -18,8 +19,11 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vue/test-utils": "^2.4.6",
+    "jsdom": "^24.1.3",
     "sass-embedded": "^1.92.1",
     "vite": "^7.0.6",
-    "vite-plugin-vue-devtools": "^8.0.0"
+    "vite-plugin-vue-devtools": "^8.0.0",
+    "vitest": "^2.1.4"
   }
 }

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -355,6 +355,29 @@ watch(token, async (newToken) => {
 });
 
 onMounted(async () => {
+  if (window.location.pathname === '/admin' && window.location.hash) {
+    const fragment = window.location.hash.startsWith('#')
+      ? window.location.hash.slice(1)
+      : window.location.hash;
+    const params = new URLSearchParams(fragment);
+    const accessToken = params.get('access_token') || '';
+    const errorCode = params.get('error') || '';
+    const hasAccessToken = accessToken.length > 0;
+    const hasError = errorCode.length > 0;
+    if (hasAccessToken || hasError) {
+      try {
+        if (hasAccessToken) {
+          await finalizeTwitchSuccess(accessToken, params.get('state'));
+        } else if (hasError) {
+          const description = params.get('error_description') || errorCode || 'Connexion Twitch refusée.';
+          finalizeTwitchError(description);
+        }
+      } finally {
+        history.replaceState(null, document.title, `${window.location.pathname}${window.location.search}`);
+      }
+    }
+  }
+
   window.addEventListener('storage', handleTwitchStorageEvent);
   scheduleGoogleInitRetry();
   await fetchAuthConfig();

--- a/frontend/tests/AdminView.spec.ts
+++ b/frontend/tests/AdminView.spec.ts
@@ -1,0 +1,89 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminView from '../src/views/AdminView.vue';
+
+const TWITCH_STATE_KEY = 'twitch_oauth_state';
+
+describe('AdminView Twitch hash fallback', () => {
+  const originalHref = window.location.href;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+
+    fetchMock = vi.fn((input: RequestInfo, init?: RequestInit) => {
+      if (typeof input === 'string' && input.endsWith('/auth/twitch')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ token: 'server-token', provider: 'twitch', name: 'Admin' }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' }
+            }
+          )
+        );
+      }
+
+      if (typeof input === 'string' && input.endsWith('/auth/config')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        );
+      }
+
+      return Promise.resolve(
+        new Response(JSON.stringify({ detail: 'not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    window.history.replaceState(null, '', originalHref);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    window.history.replaceState(null, '', originalHref);
+  });
+
+  it('processes a Twitch access token from the URL hash when mounting', async () => {
+    const stateValue = 'expected-state';
+    sessionStorage.setItem(TWITCH_STATE_KEY, stateValue);
+    window.history.replaceState(
+      null,
+      '',
+      `http://localhost/admin#access_token=test-token&state=${stateValue}`
+    );
+
+    const wrapper = mount(AdminView);
+
+    await flushPromises();
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/auth/twitch',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ access_token: 'test-token' })
+      })
+    );
+    expect(localStorage.getItem('admin_token')).toBe('server-token');
+    expect(localStorage.getItem('admin_profile')).toBe(
+      JSON.stringify({ name: 'Admin', provider: 'twitch' })
+    );
+    expect(sessionStorage.getItem(TWITCH_STATE_KEY)).toBeNull();
+    expect(window.location.hash).toBe('');
+
+    await wrapper.unmount();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
     "src/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.tsx",
-    "src/**/*.vue"
+    "src/**/*.vue",
+    "tests/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,8 +6,11 @@ export default defineConfig({
   server: {
     port: 5173,
     headers: {
-
       'Cross-Origin-Embedder-Policy': 'unsafe-none'
     }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true
   }
 })


### PR DESCRIPTION
## Summary
- add a legacy Twitch hash fallback in the admin view that reuses existing success/error handlers and clears the fragment
- configure the frontend for Vitest and add a regression test covering the hash-based admin login flow

## Testing
- npm test *(fails: vitest not found in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e18fe439b4832283e76e48a43cbaf0