### PR TITLE
Fix Spotify metadata extraction and improve ban rule cleanup

### DIFF
--- a/backend/app/crud/ban_rule.py
+++ b/backend/app/crud/ban_rule.py
@@ -9,6 +9,9 @@ from app.schemas.ban_rule import BanRuleCreate, BanRuleUpdate
 from app.utils.text import normalize
 
 
+_UNKNOWN_ARTIST_NORMALIZED = normalize("Artiste inconnu")
+
+
 def _matches_rule(song: Song, rule: BanRule) -> bool:
     matches_title = True
     if rule.title:
@@ -16,7 +19,13 @@ def _matches_rule(song: Song, rule: BanRule) -> bool:
 
     matches_artist = True
     if rule.artist:
-        matches_artist = normalize(song.artist) == normalize(rule.artist)
+        song_artist_norm = normalize(song.artist)
+        rule_artist_norm = normalize(rule.artist)
+
+        if not song_artist_norm or song_artist_norm == _UNKNOWN_ARTIST_NORMALIZED:
+            matches_artist = True
+        else:
+            matches_artist = song_artist_norm == rule_artist_norm
 
     return matches_title and matches_artist
 

--- a/backend/app/schemas/song.py
+++ b/backend/app/schemas/song.py
@@ -4,7 +4,7 @@ class SongCreate(BaseModel):
     title: str
     artist: str
     link: str
-    thumbnail: str = None
+    thumbnail: str | None = None
 
 class SongOut(SongCreate):
     id: int

--- a/backend/app/services/song_metadata.py
+++ b/backend/app/services/song_metadata.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict
+import html
+import json
+import re
+from typing import Dict, Iterable, Tuple
 
 import httpx
 
@@ -11,6 +14,84 @@ LOGGER = logging.getLogger(__name__)
 
 YOUTUBE_OEMBED = "https://www.youtube.com/oembed"
 SPOTIFY_OEMBED = "https://open.spotify.com/oembed"
+SPOTIFY_BASE_URL = "https://open.spotify.com"
+
+UNKNOWN_TITLE = "Inconnu"
+UNKNOWN_ARTIST = "Artiste inconnu"
+
+_SPOTIFY_ARTIST_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r'"artists"\s*:\s*\[\s*{[^}]*"name"\s*:\s*"(?P<name>[^\"]+)"'),
+    re.compile(r'"type"\s*:\s*"artist"[^{}]*"name"\s*:\s*"(?P<name>[^\"]+)"'),
+)
+
+_SPOTIFY_TITLE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r'"type"\s*:\s*"track"[^{}]*"name"\s*:\s*"(?P<name>[^\"]+)"'),
+    re.compile(r'"name"\s*:\s*"(?P<name>[^\"]+)"[^{}]*"type"\s*:\s*"track"'),
+)
+
+
+def _decode_json_string(value: str) -> str:
+    try:
+        return json.loads(f'"{value}"')
+    except json.JSONDecodeError:
+        return html.unescape(value)
+
+
+def _first_match(patterns: Iterable[re.Pattern[str]], text: str) -> str | None:
+    for pattern in patterns:
+        match = pattern.search(text)
+        if match:
+            return _decode_json_string(match.group("name"))
+    return None
+
+
+def _normalize_spotify_url(url: str) -> str:
+    if url.startswith("//"):
+        return f"https:{url}"
+    if url.startswith("/"):
+        return f"{SPOTIFY_BASE_URL}{url}"
+    return url
+
+
+def _extract_spotify_metadata_from_html(html_text: str) -> Tuple[str | None, str | None]:
+    title = _first_match(_SPOTIFY_TITLE_PATTERNS, html_text)
+    artist = _first_match(_SPOTIFY_ARTIST_PATTERNS, html_text)
+    return title, artist
+
+
+def _enrich_spotify_metadata(
+    client: httpx.Client, result: Dict[str, str], link: str
+) -> Tuple[str, str]:
+    title = result.get("title") or UNKNOWN_TITLE
+    artist = result.get("author_name")
+
+    if artist:
+        return title, artist
+
+    candidate_urls: list[str] = []
+    iframe_html = result.get("html") or ""
+    for match in re.finditer(r'src="(?P<src>[^"]+)"', iframe_html):
+        candidate_urls.append(_normalize_spotify_url(match.group("src")))
+
+    candidate_urls.append(link)
+
+    for candidate in candidate_urls:
+        try:
+            response = client.get(candidate)
+            response.raise_for_status()
+        except httpx.HTTPError:  # pragma: no cover - depends on external network issues
+            continue
+
+        parsed_title, parsed_artist = _extract_spotify_metadata_from_html(response.text)
+        if parsed_artist:
+            artist = parsed_artist
+        if parsed_title:
+            title = parsed_title
+
+        if artist:
+            break
+
+    return title, artist or UNKNOWN_ARTIST
 
 
 class MetadataError(RuntimeError):
@@ -23,11 +104,13 @@ def _fetch_oembed(client: httpx.Client, endpoint: str, url: str) -> Dict[str, st
     return response.json()
 
 
-def _build_song(result: Dict[str, str], link: str) -> SongCreate:
-    title = result.get("title") or "Inconnu"
-    artist = result.get("author_name") or "Artiste inconnu"
+def _build_song(
+    result: Dict[str, str], link: str, *, title: str | None = None, artist: str | None = None
+) -> SongCreate:
+    final_title = title or result.get("title") or UNKNOWN_TITLE
+    final_artist = artist or result.get("author_name") or UNKNOWN_ARTIST
     thumbnail = result.get("thumbnail_url")
-    return SongCreate(title=title, artist=artist, link=link, thumbnail=thumbnail)
+    return SongCreate(title=final_title, artist=final_artist, link=link, thumbnail=thumbnail)
 
 
 def fetch_song_metadata(link: str) -> SongCreate:
@@ -52,6 +135,10 @@ def fetch_song_metadata(link: str) -> SongCreate:
             raise MetadataError("Erreur réseau lors de la récupération des métadonnées") from exc
 
     if isinstance(result, dict):
+        if endpoint == SPOTIFY_OEMBED:
+            title, artist = _enrich_spotify_metadata(client, result, link)
+            return _build_song(result, link, title=title, artist=artist)
+
         return _build_song(result, link)
 
     raise MetadataError("Réponse invalide du fournisseur")

--- a/backend/tests/test_song_management.py
+++ b/backend/tests/test_song_management.py
@@ -65,6 +65,24 @@ def test_add_ban_rule_removes_matching_songs(session: Session) -> None:
     assert "https://youtube.com/watch?v=autre" in remaining
 
 
+def test_add_ban_rule_handles_unknown_artist_placeholder(session: Session) -> None:
+    session.add(
+        Song(
+            title="Zitti e Buoni",
+            artist="Artiste inconnu",
+            link="https://youtube.com/watch?v=maneskin",
+        )
+    )
+    session.commit()
+
+    ban_crud.add_ban_rule(
+        session,
+        BanRuleCreate(title="Zitti e Buoni", artist="Måneskin"),
+    )
+
+    assert session.query(Song).count() == 0
+
+
 def test_add_ban_rule_with_link_removes_song(session: Session) -> None:
     created = song_crud.add_or_increment_song(
         session,

--- a/backend/tests/test_song_metadata.py
+++ b/backend/tests/test_song_metadata.py
@@ -1,0 +1,71 @@
+from app.services import song_metadata
+
+
+class DummyResponse:
+    def __init__(self, *, json_data=None, text: str = "") -> None:
+        self._json_data = json_data
+        self.text = text
+
+    def raise_for_status(self) -> None:  # pragma: no cover - nothing to raise
+        return None
+
+    def json(self) -> dict:
+        if self._json_data is None:
+            raise RuntimeError("No JSON payload defined")
+        return self._json_data
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self._responses = responses
+
+    def get(self, url, params=None, **kwargs):
+        if params is not None:
+            key = (url, tuple(sorted(params.items())))
+        else:
+            key = url
+
+        if key not in self._responses:
+            raise AssertionError(f"Unexpected request: {key}")
+
+        payload = self._responses[key]
+        return DummyResponse(**payload)
+
+
+def test_enrich_spotify_metadata_extracts_artist_and_title():
+    oembed_payload = {
+        "title": "Zitti e Buoni",
+        "html": '<iframe src="https://open.spotify.com/embed/track/123?utm_source=oembed"></iframe>',
+        "thumbnail_url": "https://i.scdn.co/image/abc",
+    }
+
+    spotify_html = (
+        '{"type":"track","name":"Zitti e Buoni","artists":[{"name":"M\\u00e5neskin"}]}'
+    )
+
+    responses = {
+        "https://open.spotify.com/embed/track/123?utm_source=oembed": {
+            "text": spotify_html
+        },
+    }
+
+    client = DummyClient(responses)
+    title, artist = song_metadata._enrich_spotify_metadata(  # pylint: disable=protected-access
+        client, oembed_payload, "https://open.spotify.com/track/123"
+    )
+
+    assert title == "Zitti e Buoni"
+    assert artist == "Måneskin"
+
+
+def test_build_song_prefers_overrides():
+    result = {"title": "Fallback", "author_name": "Unknown", "thumbnail_url": None}
+    created = song_metadata._build_song(  # pylint: disable=protected-access
+        result,
+        "https://example.com",
+        title="Actual Title",
+        artist="Actual Artist",
+    )
+
+    assert created.title == "Actual Title"
+    assert created.artist == "Actual Artist"


### PR DESCRIPTION
## Summary
- ensure ban rules remove songs stored with placeholder artists so bans take effect immediately
- enrich Spotify metadata retrieval by parsing embed pages to recover artist information and support optional thumbnails
- add regression coverage for ban-rule cleanup and the Spotify metadata parser

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e19ca22ba4832296c07063d9eb4279